### PR TITLE
Fix version picker.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -3,7 +3,7 @@
 export GOFLAGS='-mod=vendor'
 
 if command -v git >/dev/null 2>&1; then
-  gitCommit="$(git show-ref --head HEAD -s)"
+  gitCommit="$(git rev-parse HEAD)"
 else
   gitCommit="$GIT_COMMIT"
 fi


### PR DESCRIPTION
If I try to build it on MacOs I get `usage` output from `go build`. It's because current git command returns:
```
git show-ref --head HEAD -s
a54a0338e79d62f6a2d6227babe888a1f61630e2
a54a0338e79d62f6a2d6227babe888a1f61630e2
```